### PR TITLE
Updated team service class to add participant with team to DB

### DIFF
--- a/src/main/java/com/jbhunt/infrastructure/universityhackathon/services/TeamService.java
+++ b/src/main/java/com/jbhunt/infrastructure/universityhackathon/services/TeamService.java
@@ -34,7 +34,7 @@ public class TeamService {
 
         //get hackathonEventID
         int hackathonEventID = -1;
-       List<HackathonEvent> current = hackathonEventService.getUpcomingHackathonEvents(100);
+       List<HackathonEvent> current = hackathonEventService.getCurrentHackathon();
         if(!current.isEmpty()) {
             hackathonEventID = current.get(0).getHackathonEventID();
 
@@ -63,7 +63,7 @@ public class TeamService {
 
         //get hackathonEventID
         int hackathonEventID = -1;
-        List<HackathonEvent> current = hackathonEventService.getUpcomingHackathonEvents(30);
+        List<HackathonEvent> current = hackathonEventService.getCurrentHackathon();
         if(!current.isEmpty()) {
             hackathonEventID = current.get(0).getHackathonEventID();
 


### PR DESCRIPTION
Earlier, was ONLY able to add participant to DB if they paired with random team, in which case their team name was left initially as a blank string.

Was NOT able to add participant to DB if they belonged to a particular team, in which case their team name was a non-blank string.

Modified two functions called "createTeam" from:

List<HackathonEvent> current = hackathonEventService.getUpcomingHackathonEvents(30)

to
List<HackathonEvent> current = hackathonEventService.getCurrentHackathon();

No longer receiving error logs and able to successfully add participant with team into DB.